### PR TITLE
Feat: #12 챔피언 선택 기능

### DIFF
--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,0 +1,3 @@
+export const STORAGE_KEYS = {
+  SELECTED_CHAMPIONS: "selectedChampions",
+} as const;

--- a/src/features/champ-list/ui/ChampList.tsx
+++ b/src/features/champ-list/ui/ChampList.tsx
@@ -1,5 +1,6 @@
-import { useGetChampList } from "../model/useChampList";
 import type { Champion } from "@/@types";
+import { useGetChampList } from "../model/useChampList";
+import ChampListItem from "./ChampListItem";
 
 function ChampList() {
   const { data: champions, isLoading, error } = useGetChampList();
@@ -26,20 +27,7 @@ function ChampList() {
     <div className="container mx-auto px-4 py-8">
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
         {champions?.map((champ: Champion) => (
-          <div
-            key={champ.id}
-            className="flex flex-col items-center p-4 rounded-lg bg-white dark:bg-gray-800 shadow-md hover:shadow-lg transition-shadow"
-          >
-            <img
-              src={`https://ddragon.leagueoflegends.com/cdn/15.9.1/img/champion/${champ.image.full}`}
-              alt={champ.name}
-              className="w-16 h-16 rounded-full mb-2"
-            />
-            <h3 className="font-semibold text-center">{champ.name}</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
-              {champ.title}
-            </p>
-          </div>
+          <ChampListItem key={champ.id} champ={champ} />
         ))}
       </div>
     </div>

--- a/src/features/champ-list/ui/ChampListItem.tsx
+++ b/src/features/champ-list/ui/ChampListItem.tsx
@@ -1,0 +1,34 @@
+import type { Champion } from "@/@types";
+import { usePatchVersionStore } from "@/shared/store/patchVersionStore";
+import { useSelectedChampions } from "@/shared/store/useSelectedChampions";
+
+interface ChampListItemProps {
+  champ: Champion;
+}
+
+function ChampListItem({ champ }: ChampListItemProps) {
+  const { version } = usePatchVersionStore();
+  const { toggleChampion, isChampionSelected } = useSelectedChampions();
+  const isSelected = isChampionSelected(champ.id);
+
+  return (
+    <div
+      onClick={() => toggleChampion(champ)}
+      className={`flex flex-col items-center p-4 rounded-lg bg-white dark:bg-gray-800 shadow-md hover:shadow-lg transition-shadow cursor-pointer ${
+        isSelected ? "ring-2 ring-blue-500" : ""
+      }`}
+    >
+      <img
+        src={`https://ddragon.leagueoflegends.com/cdn/${version}/img/champion/${champ.image.full}`}
+        alt={champ.name}
+        className="w-16 h-16 rounded-full mb-2"
+      />
+      <h3 className="font-semibold text-center">{champ.name}</h3>
+      <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
+        {champ.title}
+      </p>
+    </div>
+  );
+}
+
+export default ChampListItem;

--- a/src/shared/store/useSelectedChampions.ts
+++ b/src/shared/store/useSelectedChampions.ts
@@ -1,0 +1,62 @@
+import { create } from "zustand";
+import type { Champion } from "@/@types";
+import { STORAGE_KEYS } from "@/constants/storageKeys";
+
+interface SelectedChampionsStore {
+  selectedChampions: Champion[];
+  toggleChampion: (champion: Champion) => void;
+  isChampionSelected: (championId: string) => boolean;
+  removeChampion: (championId: string) => void;
+  clearChampions: () => void;
+}
+
+export const useSelectedChampions = create<SelectedChampionsStore>(
+  (set, get) => ({
+    selectedChampions: (() => {
+      const savedChampions = localStorage.getItem(
+        STORAGE_KEYS.SELECTED_CHAMPIONS
+      );
+      return savedChampions ? JSON.parse(savedChampions) : [];
+    })(),
+
+    toggleChampion: (champion: Champion) => {
+      set((state) => {
+        const isSelected = state.selectedChampions.some(
+          (champ) => champ.id === champion.id
+        );
+        const newSelectedChampions = isSelected
+          ? state.selectedChampions.filter((champ) => champ.id !== champion.id)
+          : [...state.selectedChampions, champion];
+
+        localStorage.setItem(
+          STORAGE_KEYS.SELECTED_CHAMPIONS,
+          JSON.stringify(newSelectedChampions)
+        );
+
+        return { selectedChampions: newSelectedChampions };
+      });
+    },
+
+    isChampionSelected: (championId: string) => {
+      return get().selectedChampions.some((champ) => champ.id === championId);
+    },
+
+    removeChampion: (championId: string) => {
+      set((state) => {
+        const newSelectedChampions = state.selectedChampions.filter(
+          (champ) => champ.id !== championId
+        );
+        localStorage.setItem(
+          STORAGE_KEYS.SELECTED_CHAMPIONS,
+          JSON.stringify(newSelectedChampions)
+        );
+        return { selectedChampions: newSelectedChampions };
+      });
+    },
+
+    clearChampions: () => {
+      set({ selectedChampions: [] });
+      localStorage.removeItem(STORAGE_KEYS.SELECTED_CHAMPIONS);
+    },
+  })
+);


### PR DESCRIPTION
## 🔧 작업 개요

- 사용자가 룰렛에 돌릴 챔피언을 선택할 수 있도록 챔피언 선택 기능 구현

## ✅ 체크리스트

- [x] 관련 이슈를 링크했나요? (#12 )
- [x] 기능 동작을 테스트했나요?
- [x] 로직이나 UI 변경 시 문서/주석 등을 업데이트했나요?

## 📝 변경 사항

- ChampList 하위에 Item 컴포넌트로 분리
- zustand를 이용하여 선택된 챔피언 관리
- zustand 데이터 로컬스토리지와 동기화

## 💬 기타 사항

- ...

## 📷 스크린샷 (선택)

- ![데스크톱](https://github.com/user-attachments/assets/4cf194d5-64fb-42cd-be0b-9f3f4b839582)
